### PR TITLE
Scroll Tweaks and Fixes

### DIFF
--- a/404cafeclub/css/cyanobacteria.css
+++ b/404cafeclub/css/cyanobacteria.css
@@ -328,6 +328,7 @@ a:visited {
 	overflow-x: hidden;
 	max-height: 950px; /* this is hardcoded to make it match the length of the content to its left */
 	scrollbar-color: #919ed7 #e5e8f5;
+	scrollbar-width: thin;
 	border-style: none;
 }
 

--- a/404cafeclub/css/cyanobacteria.css
+++ b/404cafeclub/css/cyanobacteria.css
@@ -321,13 +321,24 @@ a:visited {
 }
 
 .scroll {
-        display: flex;
-        flex-direction: column;
+	display: flex;
+	flex-direction: column;
 	flex-grow: 1;
-	overflow-y: scroll;
-        max-height: 950px; /* this is hardcoded to make it match the length of the content to its left */
+	overflow-y: auto;
+	overflow-x: hidden;
+	max-height: 950px; /* this is hardcoded to make it match the length of the content to its left */
 	scrollbar-color: #919ed7 #e5e8f5;
-        border-style: none;
+	border-style: none;
+}
+
+/* use this to force a horizontal scroll bar */
+.scroll-x {
+	overflow-x: scroll;
+}
+
+/* use this to force a verticla scroll bar */
+.scroll-y {
+	overflow-y: scroll;
 }
 
 .scroll article {

--- a/404cafeclub/css/data.css
+++ b/404cafeclub/css/data.css
@@ -61,6 +61,7 @@ h6 {
 	position: relative;
 	overflow-y: auto;
 	scrollbar-color: #919ed7 #e5e8f5;
+	scrollbar-width: thin;
 }
 
 .scroll>div {

--- a/404cafeclub/css/data.css
+++ b/404cafeclub/css/data.css
@@ -59,7 +59,7 @@ h6 {
 .scroll {
 	flex-grow: 1;
 	position: relative;
-	overflow-y: scroll;
+	overflow-y: auto;
 	scrollbar-color: #919ed7 #e5e8f5;
 }
 


### PR DESCRIPTION
- Changed the scroll class to only show scrollbars if there is actually enough content to scroll. Fixes the scrollbar always being visible on the data page.
- Set the scrollbar width to thin to increase useable space for content in sidebar and scrollable areas.
- Created a scroll-x and scroll-y class to force horizontal or vertical scroll if needed - may be helpful for the future